### PR TITLE
Use existing nfos as a base

### DIFF
--- a/lc.py
+++ b/lc.py
@@ -73,8 +73,8 @@ if __name__ == '__main__':
             NOUPLOAD = True
         if opt in ('--quality', '-q'):
             DEFAULT_QUALITY = val
-        if opt in ('--skip_quality'):
-            SKIP_QUALITY = val
+        if opt in ('--skipquality'):
+            SKIP_QUALITY = True
     
     for cur_file_path in file_path_list:
         print "Calling Lift Cup for file", cur_file_path 

--- a/lift_cup.py
+++ b/lift_cup.py
@@ -255,7 +255,7 @@ class LiftCup(object):
         old_name: The original name of this release before we scenified it
             """
         self.logger("Creating NFO at", nfo_path)
-        nfo = open(nfo_path, 'w')
+        nfo = open(nfo_path, 'a')
         nfo.write('Original name: '+old_name+'\n')
         if nfo_string:
             nfo.write(nfo_string+'\n')
@@ -284,8 +284,13 @@ class LiftCup(object):
         if not self.rar_release(files_to_rar, rar_base_name):
             return
 
-        # make an nfo
+        # make an nfo if it doesn't exist
+        cur_file_name = os.path.splitext(cur_file)[0]
+        cur_file_nfo = cur_file_name + '.nfo'
         nfo_file_path = rar_base_name + '.nfo'
+        if os.path.isfile(cur_file_nfo):
+            self.logger("Using existing nfo at", cur_file_nfo, "as a base") 
+            shutil.copyfile(cur_file_nfo, nfo_file_path)
         self.create_nfo(nfo_file_path, self.file)
     
         # par it


### PR DESCRIPTION
If there is a nfo file for a file, use it, and append the Lift-Cup nfo strings to it.
If not, append will create the file as before.

Been using this to upload today, and seems to work fine.
